### PR TITLE
Replace host OS detection code to deal with Java >9 versions

### DIFF
--- a/AggregateAppEngineUpdater/build.gradle
+++ b/AggregateAppEngineUpdater/build.gradle
@@ -23,6 +23,11 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
   compile group: 'commons-logging', name: 'commons-logging', version: '1.2'
   compile group: 'org.bushe', name: 'eventbus', version: '1.4'
+  testCompile('junit:junit:4.12') {
+    exclude group: 'org.hamcrest'
+  }
+  testCompile 'org.hamcrest:hamcrest-library:1.3'
+  testCompile 'com.github.npathai:hamcrest-optional:2.0.0'
 }
 
 jar {

--- a/AggregateAppEngineUpdater/build.gradle
+++ b/AggregateAppEngineUpdater/build.gradle
@@ -19,8 +19,6 @@ dependencies {
   compile group: 'commons-cli', name: 'commons-cli', version: '1.3.1'
   compile group: 'commons-codec', name: 'commons-codec', version: '1.10'
   compile group: 'commons-io', name: 'commons-io', version: '2.4'
-  compile group: 'commons-lang', name: 'commons-lang', version: '2.3'
-  compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
   compile group: 'commons-logging', name: 'commons-logging', version: '1.2'
   compile group: 'org.bushe', name: 'eventbus', version: '1.4'
   testCompile('junit:junit:4.12') {

--- a/AggregateAppEngineUpdater/src/main/java/org/opendatakit/appengine/updater/AppCfgWrapper.java
+++ b/AggregateAppEngineUpdater/src/main/java/org/opendatakit/appengine/updater/AppCfgWrapper.java
@@ -21,7 +21,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 
-import org.apache.commons.lang.SystemUtils;
 import org.opendatakit.apache.commons.exec.CommandLine;
 import org.opendatakit.apache.commons.exec.DefaultExecutor;
 import org.opendatakit.apache.commons.exec.ExecuteException;
@@ -47,8 +46,8 @@ public class AppCfgWrapper {
   public static File locateTokenFile() {
     String userhome = System.getProperty("user.home");
     String althome = null;
-    if ( SystemUtils.IS_OS_WINDOWS ) {
-      String username = System.getProperty("user.name");
+    if ( Host.isWindows() ) {
+        String username = System.getProperty("user.name");
       althome = "C:\\Users\\" + username;
     }
     File dirHome = new File(userhome);

--- a/AggregateAppEngineUpdater/src/main/java/org/opendatakit/appengine/updater/Host.java
+++ b/AggregateAppEngineUpdater/src/main/java/org/opendatakit/appengine/updater/Host.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.appengine.updater;
+
+
+import static org.opendatakit.appengine.updater.Host.OperatingSystem.LINUX;
+import static org.opendatakit.appengine.updater.Host.OperatingSystem.MAC;
+import static org.opendatakit.appengine.updater.Host.OperatingSystem.WIN;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class Host {
+  public static boolean isMac() {
+    return OperatingSystem.get() == MAC;
+  }
+
+  public static boolean isLinux() {
+    return OperatingSystem.get() == LINUX;
+  }
+
+  public static boolean isWindows() {
+    return OperatingSystem.get() == WIN;
+  }
+
+  public static String getOsName() {
+    return OperatingSystem.get().name;
+  }
+
+  enum OperatingSystem {
+    WIN("windows", "windows"),
+    LINUX("linux", "nix", "nux", "aix"),
+    MAC("mac", "mac");
+
+    private final String name;
+    private final List<String> tests;
+
+    OperatingSystem(String name, String... tests) {
+      this.name = name;
+      this.tests = Arrays.asList(tests);
+    }
+
+    static OperatingSystem get() {
+      String rawOs = System.getProperty("os.name").toLowerCase();
+      return Stream.of(WIN, LINUX, MAC)
+          .filter(operatingSystem -> operatingSystem.test(rawOs))
+          .findFirst()
+          .orElseThrow(() -> new RuntimeException("Unrecognized operating system " + rawOs));
+    }
+
+    private boolean test(String os) {
+      return tests.stream().anyMatch(os::contains);
+    }
+  }
+}

--- a/AggregateAppEngineUpdater/src/test/java/org/opendatakit/appengine/updater/HostTest.java
+++ b/AggregateAppEngineUpdater/src/test/java/org/opendatakit/appengine/updater/HostTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Nafundi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.appengine.updater;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class HostTest {
+
+  @Test
+  public void knows_if_it_is_a_Linux_host() {
+    // As per http://lopica.sourceforge.net/os.html
+    withSystemProperty("os.name", "Linux", () -> {
+      assertThat(Host.isLinux(), is(true));
+      assertThat(Host.isWindows(), is(false));
+      assertThat(Host.isMac(), is(false));
+      assertThat(Host.getOsName(), is("linux"));
+    });
+    withSystemProperty("os.name", "Digital Unix", () -> {
+      assertThat(Host.isLinux(), is(true));
+      assertThat(Host.isWindows(), is(false));
+      assertThat(Host.isMac(), is(false));
+      assertThat(Host.getOsName(), is("linux"));
+    });
+    withSystemProperty("os.name", "AIX", () -> {
+      assertThat(Host.isLinux(), is(true));
+      assertThat(Host.isWindows(), is(false));
+      assertThat(Host.isMac(), is(false));
+      assertThat(Host.getOsName(), is("linux"));
+    });
+  }
+
+  @Test
+  public void knows_if_it_is_a_Windows_host() {
+    withSystemProperty("os.name", "Windows XP", () -> {
+      assertThat(Host.isLinux(), is(false));
+      assertThat(Host.isWindows(), is(true));
+      assertThat(Host.isMac(), is(false));
+      assertThat(Host.getOsName(), is("windows"));
+    });
+  }
+
+  @Test
+  public void knows_if_it_is_a_Mac_host() {
+    withSystemProperty("os.name", "Mac OS X", () -> {
+      assertThat(Host.isLinux(), is(false));
+      assertThat(Host.isWindows(), is(false));
+      assertThat(Host.isMac(), is(true));
+      assertThat(Host.getOsName(), is("mac"));
+    });
+  }
+
+  private void withSystemProperty(String key, String value, Runnable block) {
+    String backupValue = System.getProperty(key);
+    System.setProperty(key, value);
+    block.run();
+    System.setProperty(key, backupValue);
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/opendatakit/aggregate/issues/317

This PR replaces the obsolete Apache Commons method with an up-to-date, unit tested (and battle-tested) host OS detection algorithm we use in Briefcase.